### PR TITLE
Fix compiler warning

### DIFF
--- a/emlconv.cc
+++ b/emlconv.cc
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
     if(formid=="110a") { //  verkiezingsdefinitie
       auto start = doc.child("EML").child("ElectionEvent").child("Election");
       //
-      int noSeats;
+      int noSeats = 0;
       string electionName, electionDomain;
       string category, subcategory;
       for(const auto& node : start) {


### PR DESCRIPTION
Compiler complains about `noSeats` not initialized with the following warning:
```
In file included from /source/eml2sql/sqlwriter.hh:5,
                 from /source/eml2sql/emlconv.cc:8:
In constructor 'constexpr std::__detail::__variant::_Uninitialized<_Type, true>::_Uninitialized(std::in_place_index_t<0>, _Args&& ...) [with _Args = {int&}; _Type = int]',
    inlined from 'constexpr std::__detail::__variant::_Variadic_union<_First, _Rest ...>::_Variadic_union(std::in_place_index_t<0>, _Args&& ...) [with _Args = {int&}; _First = int; _Rest = {unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]' at /usr/include/c++/12/variant:385:4,
    inlined from 'constexpr std::__detail::__variant::_Variadic_union<_First, _Rest ...>::_Variadic_union(std::in_place_index_t<_Np>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}; _First = double; _Rest = {int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]' at /usr/include/c++/12/variant:391:4,
    inlined from 'constexpr std::__detail::__variant::_Variant_storage<false, _Types ...>::_Variant_storage(std::in_place_index_t<_Np>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}; _Types = {double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]' at /usr/include/c++/12/variant:460:4,
    inlined from 'constexpr std::__detail::__variant::_Copy_ctor_base<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Copy_ctor_base(std::in_place_index_t<_Idx>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}][inherited from std::__detail::__variant::_Variant_storage<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]' at /usr/include/c++/12/variant:557:20,
    inlined from 'constexpr std::__detail::__variant::_Move_ctor_base<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Move_ctor_base(std::in_place_index_t<_Idx>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}][inherited from std::__detail::__variant::_Variant_storage<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]' at /usr/include/c++/12/variant:594:20,
    inlined from 'constexpr std::__detail::__variant::_Copy_assign_base<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Copy_assign_base(std::in_place_index_t<_Idx>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}][inherited from std::__detail::__variant::_Variant_storage<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]' at /usr/include/c++/12/variant:632:20,
    inlined from 'constexpr std::__detail::__variant::_Move_assign_base<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::_Move_assign_base(std::in_place_index_t<_Idx>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}][inherited from std::__detail::__variant::_Variant_storage<false, double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]' at /usr/include/c++/12/variant:684:20,
    inlined from 'constexpr std::__detail::__variant::_Variant_base<_Types>::_Variant_base(std::in_place_index_t<_Np>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}; _Types = {double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]' at /usr/include/c++/12/variant:746:45,
    inlined from 'constexpr std::variant<_Types>::variant(std::in_place_index_t<_Np>, _Args&& ...) [with long unsigned int _Np = 1; _Args = {int&}; _Tp = int; <template-parameter-2-4> = void; _Types = {double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]' at /usr/include/c++/12/variant:1448:57,
    inlined from 'constexpr std::variant<_Types>::variant(_Tp&&) [with _Tp = int&; <template-parameter-2-2> = void; <template-parameter-2-3> = void; _Tj = int; <template-parameter-2-5> = void; _Types = {double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]' at /usr/include/c++/12/variant:1419:27,
    inlined from 'constexpr std::pair<_T1, _T2>::pair(_U1&&, _U2&&) [with _U1 = const char (&)[6]; _U2 = int&; typename std::enable_if<(std::_PCC<true, _T1, _T2>::_MoveConstructiblePair<_U1, _U2>() && std::_PCC<true, _T1, _T2>::_ImplicitlyMoveConvertiblePair<_U1, _U2>()), bool>::type <anonymous> = true; _T1 = const char*; _T2 = std::variant<double, int, unsigned int, long int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >]' at /usr/include/c++/12/bits/stl_pair.h:535:35,
    inlined from 'int main(int, char**)' at /source/eml2sql/emlconv.cc:870:1:
/usr/include/c++/12/variant:225:11: warning: 'noSeats' may be used uninitialized [-Wmaybe-uninitialized]
  225 |         : _M_storage(std::forward<_Args>(__args)...)
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/source/eml2sql/emlconv.cc: In function 'int main(int, char**)':
/source/eml2sql/emlconv.cc:354:11: note: 'noSeats' was declared here
  354 |       int noSeats;
      |           ^~~~~~~
```