### PR TITLE
International place of residence support and minor EP fixes

### DIFF
--- a/emlconv.cc
+++ b/emlconv.cc
@@ -672,7 +672,7 @@ Regio,RegioCode,OuderRegioCode
                     kieskringId = -1;
                   }
                 }
-                else if(category=="TK") {
+                else if(category=="TK" || category=="EP") {
                   kieskringName=runame;
                   kieskringHSB=ruId;
                   kieskringId = atoi(&ruId.at(3));


### PR DESCRIPTION
### Properly parse place of residence for non NL candidates
According to the EML_NL standard, the `QualifyingAddress` can be defined as (examples from `Kandidatenlijsten_TK2023_Amsterdam.eml.xml`):
No country specified, in which case we set countrycode to `NL`
```xml
<QualifyingAddress>
  <xal:Locality>
    <xal:LocalityName>Amsterdam</xal:LocalityName>
  </xal:Locality>
</QualifyingAddress>
```
Country specified, then we have to traverse the XML DOM slightly differently to find the `xal:LocalityName` and we can also fetch the `xal:CountryNameCode`
```xml
<QualifyingAddress>
  <xal:Country>
    <xal:CountryNameCode>US</xal:CountryNameCode>
    <xal:Locality>
      <xal:LocalityName>New York</xal:LocalityName>
    </xal:Locality>
  </xal:Country>
</QualifyingAddress>
```
This PR makes sure that in both cases, the sqlite database is filled with `woonplaats` if available, and adds `landcode` as a new column in the `candentries` table.

### Ignoring XML namespace for candidate information
Parsing of `<Candidate>` nodes has been changed so that instead of 
```cpp
node.child('xal:Locality')
``` 
we use an XPath query with [local-name](https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/local-name) as follows:
```cpp
node.select_node("./*[local-name()='Locality']
```
This is for backwards-compatibility with [older EP files](https://data.overheid.nl/dataset/verkiezingsuitslag-europees-parlement-2019) which used a different XML namespace.

### Minor change for EP  
`ruaffvotecounts` for formid `510d` for EP work the same as for TK, since there are still "HSBs" and "Kieskringen" defined in the reportingunits in the "Totaaltelling".