### PR TITLE
added support for metadata used in GR2026

### DIFF
--- a/emlconv.cc
+++ b/emlconv.cc
@@ -6,6 +6,7 @@
 #include <set>
 #include <filesystem>
 #include "sqlwriter.hh"
+#include "string.h"
 using namespace std;
 
 /* Every election has one or more KIESKRINGs. 
@@ -790,15 +791,25 @@ Regio,RegioCode,OuderRegioCode
                 //    <kr:Investigation ReasonCode="stembiljetten deels herteld">false</kr:Investigation>
                 //  </kr:ReportingUnitInvestigations>
 
-
                 if(invname== "kr:Investigation") {
+
                   string reason = s3.attribute("ReasonCode").value();
-                            sqw.addValue({{"electionId", electionId},{"kieskring", kieskringName}, {"kieskringHSB", kieskringHSB}, {"kieskringId", kieskringId},
-                            {"formid", formid}, {"gemeente", gemeente},
-                            {"gemeenteId", gemeenteId},
-                            {"stembureau", stembureau},
-                            {"stembureauId", stembureauId},
-                            {"postcode", postcode},{"category", lname},{"kind", reason}, {"value", atoi(s3.begin()->value())}}, "rumeta");
+                  string val = "";
+                  if (strncmp(s3.begin()->value(), "true", 4) == 0) {
+                    val = "1";
+                  }
+                  else if (strncmp(s3.begin()->value(), "false", 5) == 0) {
+                    val = "0";
+                  }
+
+                  if (val[0] != '\0') {
+                    sqw.addValue({{"electionId", electionId},{"kieskring", kieskringName}, {"kieskringHSB", kieskringHSB}, {"kieskringId", kieskringId},
+                    {"formid", formid}, {"gemeente", gemeente},
+                    {"gemeenteId", gemeenteId},
+                    {"stembureau", stembureau},
+                    {"stembureauId", stembureauId},
+                    {"postcode", postcode},{"category", lname},{"kind", reason}, {"value", val}}, "rumeta");
+                  }
                 }
                 else
                   cout<<"Unknown 510 field in ReportingUnitInvestigations: '"<<invname<<"'"<<endl;

--- a/emlconv.cc
+++ b/emlconv.cc
@@ -779,6 +779,33 @@ Regio,RegioCode,OuderRegioCode
 
                             //              cout<<"  uncountedvotes "<<s2.begin()->value()<<", reason: "<<reason<<endl;
             }
+            else if(lname=="kr:ReportingUnitInvestigations") {
+
+              for(const auto& s3 : s2) {
+                string invname = s3.name();
+                // Extra metadata, used in GR2026
+                // <kr:ReportingUnitInvestigations>
+                //    <kr:Investigation ReasonCode="toegelaten kiezers opnieuw vastgesteld">false</kr:Investigation>
+                //    <kr:Investigation ReasonCode="onderzocht vanwege andere reden">false</kr:Investigation>
+                //    <kr:Investigation ReasonCode="stembiljetten deels herteld">false</kr:Investigation>
+                //  </kr:ReportingUnitInvestigations>
+
+
+                if(invname== "kr:Investigation") {
+                  string reason = s3.attribute("ReasonCode").value();
+                            sqw.addValue({{"electionId", electionId},{"kieskring", kieskringName}, {"kieskringHSB", kieskringHSB}, {"kieskringId", kieskringId},
+                            {"formid", formid}, {"gemeente", gemeente},
+                            {"gemeenteId", gemeenteId},
+                            {"stembureau", stembureau},
+                            {"stembureauId", stembureauId},
+                            {"postcode", postcode},{"category", lname},{"kind", reason}, {"value", atoi(s3.begin()->value())}}, "rumeta");
+                }
+                else
+                  cout<<"Unknown 510 field in ReportingUnitInvestigations: '"<<invname<<"'"<<endl;
+
+              }
+
+            }
             else
               cout<<"Unknown 510 field in ReportingUnit: '"<<lname<<"'"<<endl;
 


### PR DESCRIPTION
GR2026 EML files contain more metadata. As per documentation:

> Element ReportingUnitInvestigations bevat informatie over of een bepaalde ReportingUnit onderzoek heeft gedaan naar de uitslag vanwege bijvoorbeeld een onverklaard verschil of een andere fout. Het bevat de combinaties aan ‘vinkjes’ zoals deze op de modellen voor decentrale- en centrale stemopneming staan. Dit element is alleen bedoeld voor gebruik in EML 510b en gaat dus over stembureaus.

Closes #11 